### PR TITLE
Added support to set the document context by a prop

### DIFF
--- a/src/preact-portal.js
+++ b/src/preact-portal.js
@@ -28,7 +28,14 @@ export default class Portal extends Component {
 	}
 
 	findNode(node) {
-		return typeof node==='string' ? document.querySelector(node) : node;
+		return typeof node==='string' ? this.getDocument().querySelector(node) : node;
+	}
+	
+	getDocument() {
+		if (this.props.getDocument) {
+			return this.props.getDocument();
+		}
+		return document;
 	}
 
 	renderLayer(show=true) {


### PR DESCRIPTION
In some cases there is a need to provide different document context, like when rendering the portal inside of a friendly iframe. 